### PR TITLE
the former STABLE_DIFFUSION_URL variable is not intuitive

### DIFF
--- a/agent_jarvis/.env_template
+++ b/agent_jarvis/.env_template
@@ -38,9 +38,8 @@ JARVIS_CHAT_HISTORY_DIR=./chathistory
 
 # =========== Stable diffusion
 # The stable diffusion webui api's address.
-# e.g. http://192.168.3.254:1997/sdapi/v1
-# NOTE 1: REMOVE the final slash '/', or sd-webui will not recognize the request
-# NOTE 2: Do *** NOT **** use 'localhost' or '127.0.0.1' or other loopback address, 
+# e.g. http://192.168.3.254:1997
+# NOTE: Do *** NOT **** use 'localhost' or '127.0.0.1' or other loopback address, 
 #   since we don't use host network in docker.
 DEMO_STABLE_DIFFUSION_ADDRESS=
 ### The following 6 variables are optional. You can leave them empty if you want.

--- a/agent_jarvis/README.md
+++ b/agent_jarvis/README.md
@@ -61,9 +61,8 @@ To enable Jarvis with drawing capabilities, you will need to set up an Stable Di
 cd docker
 
 # Edit '.env' and configure DEMO_STABLE_DIFFUSION_ADDRESS
-# e.g. http://192.168.3.254:1997/sdapi/v1
-# NOTE 1: REMOVE the final slash '/', or sd-webui will not recognize the request
-# NOTE 2: Do *** NOT **** use 'localhost' or '127.0.0.1' or other loopback address, 
+# e.g. http://192.168.3.254:1997
+# NOTE: Do *** NOT **** use 'localhost' or '127.0.0.1' or other loopback address, 
 #   since we don't use host network in docker.
 vim jarvis/.env
 

--- a/example_modules/demo_modules/stable_diffusion.module.py
+++ b/example_modules/demo_modules/stable_diffusion.module.py
@@ -24,6 +24,7 @@ def reg_or_not():
         logger.warn("'STABLE_DIFFUSION_URL' is not provided, stable_diffusion function will not available")
         return
 
+    # TODO: Remove support for 'http://xxxx/sdapi/v1'
     if stable_diffusion_address.endswith('/sdapi/v1') or stable_diffusion_address.endswith('/sdapi/v1/'):
         logger.warn("'STABLE_DIFFUSION_URL' is expected to be something like: http://host[:port], "
                     "the form 'http://host[:port]/sdapi/v1' will be deprecated in the future.")

--- a/example_modules/demo_modules/stable_diffusion.module.py
+++ b/example_modules/demo_modules/stable_diffusion.module.py
@@ -24,6 +24,19 @@ def reg_or_not():
         logger.warn("'STABLE_DIFFUSION_URL' is not provided, stable_diffusion function will not available")
         return
 
+    if stable_diffusion_address.endswith('/sdapi/v1') or stable_diffusion_address.endswith('/sdapi/v1/'):
+        logger.warn("'STABLE_DIFFUSION_URL' is expected to be something like: http://host[:port], "
+                    "the form 'http://host[:port]/sdapi/v1' will be deprecated in the future.")
+        if stable_diffusion_address('/sdapi/v1'):
+            stable_diffusion_address += '/txt2img'
+        else:
+            stable_diffusion_address += 'txt2img'
+    else:
+        if stable_diffusion_address.endswith('/'):
+            stable_diffusion_address += 'sdapi/v1/txt2img'
+        else:
+            stable_diffusion_address += '/sdapi/v1/txt2img'
+
     stable_diffusion_my_lora = os.getenv('DEMO_STABLE_DIFFUSION_MY_LORA')
     stable_diffusion_my_lora_trigger_word = os.getenv('DEMO_STABLE_DIFFUSION_MY_LORA_TRIGGER_WORD')
     stable_diffusion_my_name = os.getenv('DEMO_STABLE_DIFFUSION_MY_NAME')
@@ -208,14 +221,13 @@ NOTE: Just reply using these information, don't ask me anything.
         return resp
 
     async def call_sd(params: dict):
-        url = stable_diffusion_address + "/txt2img"
         headers = {
             'accept': 'application/json',
             'Content-Type': 'application/json',
         }
 
         async with aiohttp.ClientSession() as session:
-            async with session.post(url, headers=headers, data=json.dumps(params)) as response:
+            async with session.post(stable_diffusion_address, headers=headers, data=json.dumps(params)) as response:
                 resp_obj = await response.json()
                 try:
                     return resp_obj["images"][0]


### PR DESCRIPTION
Now, STABLE_DIFFUSION_URL configuration should be only the schema, host and port, something like:

http://example.com:4567/

And the former configuration is also valid.

see: https://github.com/fiatrete/OpenDAN-Personal-AI-OS/issues/15#issuecomment-1587358596_